### PR TITLE
Fix styling for MDX images

### DIFF
--- a/src/components/MDX/MDX.tsx
+++ b/src/components/MDX/MDX.tsx
@@ -205,10 +205,6 @@ const PrismCSS = p => css`
 `;
 
 const ImageCSS = css`
-  .gatsby-resp-image-background-image {
-    display: none !important;
-  }
-
   img {
     display: inline-block;
     position: relative;


### PR DESCRIPTION
For some reason adding images inside MDX content wasn't working. Surprisingly I found this piece of styling as the culprit. 
```css
.gatsby-resp-image-background-image {
  display: none !important;
}
```