### PR TITLE
Adjust image max width

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -204,7 +204,7 @@ module.exports = ({
           {
             resolve: `gatsby-remark-images`,
             options: {
-              maxWidth: 10000,
+              maxWidth: 800,
               linkImagesToOriginal: false,
               quality: 80,
               withWebp: true,


### PR DESCRIPTION
Fixes the problem which causes high res images taking the whole image width
<img width="1785" alt="image" src="https://github.com/sudaraka94/gatsby-theme-novela/assets/15868287/010f1966-6e10-4b08-a4a0-990644cc8afe">
